### PR TITLE
Add viewport header and make journal entry screens responsive

### DIFF
--- a/src/main/frontend/html/index.html
+++ b/src/main/frontend/html/index.html
@@ -1,4 +1,7 @@
 <html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
   <body>
     <div id="container"></div>
     <script src="../js/index.js"></script>

--- a/src/main/frontend/js/containers/JournalEntries.js
+++ b/src/main/frontend/js/containers/JournalEntries.js
@@ -41,8 +41,6 @@ export default class JournalEntries extends React.Component {
   render() {
     return <React.Fragment>
       <JournalEntryForm onSave={this.handleSave.bind(this)} />
-      <br />
-      <br />
       {this.renderDates()}
     </React.Fragment>
   }
@@ -70,7 +68,7 @@ export default class JournalEntries extends React.Component {
       entryDates.forEach(d => symbol.push("o"))
     }
 
-    return <Table.Cell textAlign="center">
+    return <Table.Cell key={day.unix()} textAlign="center">
       {day.format('MMM DD')}
       <br />
       {symbol}
@@ -79,7 +77,7 @@ export default class JournalEntries extends React.Component {
 
   renderGrid() {
     const days = this.getDays();
-    return <Table collapsing>
+    return <Table collapsing unstackable>
       <Table.Body>
         {days.map(week => this.renderWeek(week))}
       </Table.Body>

--- a/src/main/frontend/js/containers/JournalEntryForm.js
+++ b/src/main/frontend/js/containers/JournalEntryForm.js
@@ -38,16 +38,18 @@ export default class JournalEntryForm extends React.Component {
 
   render() {
     const { entry, saving } = this.state;
-    const action = saving ? false : <Button onClick={this.handleSave}>Save</Button>;
-    return <Input
-      action={action}
-      className="long"
-      placeholder="Say something positive..."
-      onChange={this.handleEntryChange}
-      onKeyPress={this.handleKeyPress}
-      loading={saving}
-      value={entry}
-    />
+    return <React.Fragment>
+      <Input
+        className="long"
+        fluid
+        loading={saving}
+        onChange={this.handleEntryChange}
+        onKeyPress={this.handleKeyPress}
+        placeholder="Say something positive..."
+        value={entry}
+      />
+      <Button disabled={saving} onClick={this.handleSave}>Save</Button>
+    </React.Fragment>
   }
 
   triggerOnSave() {


### PR DESCRIPTION
This makes the journal screens responsive. This is how it looks like on iPhone X:
<img width="398" alt="screen shot 2018-12-04 at 7 31 28 am" src="https://user-images.githubusercontent.com/143627/49442181-b2b28880-f796-11e8-8003-25e2b7b2d733.png">
